### PR TITLE
perf: run--watch watchman initialization in background

### DIFF
--- a/pkg/aspect/run/BUILD.bazel
+++ b/pkg/aspect/run/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 


### PR DESCRIPTION
Sometimes the watchman initialization is slow such as when the directory needs to be re-indexed. There is no reason to block the initial `bazel run --norun` while waiting for watchman to initialize.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; `run --watch`
