### PR TITLE
feat: add configure -r,-index

### DIFF
--- a/cmd/aspect/configure/BUILD.bazel
+++ b/cmd/aspect/configure/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@aspect_gazelle_runner//pkg/watchman",
         "@bazel_gazelle//language:go_default_library",
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_spf13_pflag//:pflag",
         "@com_github_spf13_viper//:viper",
     ],
 )

--- a/docs/aspect_configure.md
+++ b/docs/aspect_configure.md
@@ -44,11 +44,16 @@ aspect configure [flags]
 ```
       --exclude strings   Files to exclude from BUILD generation
   -h, --help              help for configure
+      --index string      Type of index to build before running.
+                          	all: build a full index of the workspace
+                          	none: do not build an index
+                          	lazy: builds index entries on demand (default "all")
       --mode string       Method for emitting merged BUILD files.
                           	fix: write generated and merged files to disk
                           	print: print files to stdout
                           	diff: print a unified diff (default "fix")
       --progress          Show progress throughout 'configure' invocation
+      --r                 Recursively update BUILD files in subdirectories (default true)
       --watch             Use the EXPERIMENTAL watch mode to watch for changes in the workspace and automatically 'configure' when files change
       --watchman          Use the EXPERIMENTAL watchman daemon to watch for changes across 'configure' invocations
 ```


### PR DESCRIPTION
Lazy indexing will be the default in future gazelle releases, we should provide the ability to opt-in when using `configure`.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `aspect configure [-r] [-index=all|lazy|none]` aligning with `gazelle(args)`.

### Test plan

- Manual testing; running on cli
