### PR TITLE
fix: correctly send configure--watch file deletion cycles

### DIFF
--- a/cmd/aspect/configure/configure.go
+++ b/cmd/aspect/configure/configure.go
@@ -39,6 +39,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path"
 	"slices"
 	"strconv"
 	"time"
@@ -328,7 +329,12 @@ func changesetToCycle(cs *watchman.ChangeSet) ibp.SourceInfoMap {
 	si := &ibp.SourceInfo{IsSource: &b}
 	changes := make(ibp.SourceInfoMap, len(cs.Paths))
 	for _, p := range cs.Paths {
-		changes[p] = si
+		// Determine if the change is a deletion vs regular change
+		if _, err := os.Stat(path.Join(cs.Root, p)); err != nil {
+			changes[p] = nil
+		} else {
+			changes[p] = si
+		}
 	}
 	return changes
 }


### PR DESCRIPTION
While `run --watch` can detect deletions based on how the runfiles manifest changes, deletions of source files requires an actual fs-stat to determine if the file still exists.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing
