### PR TITLE
fix: align otel semconv with otel lib version

### DIFF
--- a/pkg/telemetry/BUILD.bazel
+++ b/pkg/telemetry/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "@com_github_spf13_viper//:viper",
         "@io_opentelemetry_go_otel//:otel",
-        "@io_opentelemetry_go_otel//semconv/v1.34.0:v1_34_0",
+        "@io_opentelemetry_go_otel//semconv/v1.37.0:v1_37_0",
         "@io_opentelemetry_go_otel_exporters_stdout_stdouttrace//:stdouttrace",
         "@io_opentelemetry_go_otel_sdk//resource",
         "@io_opentelemetry_go_otel_sdk//trace",

--- a/pkg/telemetry/setup.go
+++ b/pkg/telemetry/setup.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Aspect Build Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package telemetry
 
 import (
@@ -8,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 )


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: run cli with `ASPECT_OTEL_OUT=otel.log`
