### PR TITLE
fix: nesting of run--watch otel traces, add error status

### DIFF
--- a/pkg/aspect/run/BUILD.bazel
+++ b/pkg/aspect/run/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_protobuf//encoding/protodelim",
         "@org_golang_x_sync//errgroup",

--- a/pkg/aspect/run/run.go
+++ b/pkg/aspect/run/run.go
@@ -59,6 +59,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 	traceAttr "go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
@@ -444,6 +445,9 @@ func (runner *Run) runWatch(ctx context.Context, bazelCmd []string, bzlCommandSt
 		logger.Infof("incremental --watch build: %v", detectCmd.Args)
 		incBuildErr := detectCmd.Run()
 
+		if incBuildErr != nil {
+			rebuildTrace.SetStatus(codes.Error, incBuildErr.Error())
+		}
 		rebuildTrace.End()
 
 		dtErr := changedetect.detectChanges(cs.Paths)


### PR DESCRIPTION
Fix nesting of otel events, cleanup.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
