### PR TITLE
refactor: add logging of watchman events for build|test --watch

### DIFF
--- a/pkg/aspect/build/BUILD.bazel
+++ b/pkg/aspect/build/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/bazel",
         "//pkg/ioutils",
         "//pkg/plugin/system/bep",
+        "@aspect_gazelle//common/logger",
         "@aspect_gazelle_runner//pkg/watchman",
         "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",

--- a/pkg/aspect/build/build.go
+++ b/pkg/aspect/build/build.go
@@ -45,6 +45,7 @@ import (
 	"github.com/aspect-build/aspect-cli-legacy/pkg/bazel"
 	"github.com/aspect-build/aspect-cli-legacy/pkg/ioutils"
 	"github.com/aspect-build/aspect-cli-legacy/pkg/plugin/system/bep"
+	logger "github.com/aspect-build/aspect-gazelle/common/logger"
 	"github.com/aspect-build/aspect-gazelle/runner/pkg/watchman"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -153,7 +154,7 @@ func (runner *Build) buildWatch(ctx context.Context, bazelCmd []string, streams 
 		fmt.Printf("Initial Build Failed: %v", err)
 	}
 
-	for _, err := range w.Subscribe(ctx, watchman.DeferState{DeferWithinState: "aspect-build-watch"}) {
+	for cs, err := range w.Subscribe(ctx, watchman.DeferState{DeferWithinState: "aspect-build-watch"}) {
 		if err != nil {
 			// Break the subscribe iteration if the context is done or if the watcher is closed.
 			if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
@@ -168,6 +169,8 @@ func (runner *Build) buildWatch(ctx context.Context, bazelCmd []string, streams 
 		if err := w.StateEnter("aspect-build-watch"); err != nil {
 			return fmt.Errorf("failed to enter build state: %w", err)
 		}
+
+		logger.Debugf("watchman detected changes: %v", cs.Paths)
 
 		err := runner.bzl.RunCommand(streams, nil, bazelCmd...)
 		if err != nil {

--- a/pkg/aspect/test/BUILD.bazel
+++ b/pkg/aspect/test/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/bazel",
         "//pkg/ioutils",
         "//pkg/plugin/system/bep",
+        "@aspect_gazelle//common/logger",
         "@aspect_gazelle_runner//pkg/watchman",
         "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
