### PR TITLE
fix: bes handler hanging when command has no bes events

### DIFF
--- a/integration_tests/aspect/lint_test.bats
+++ b/integration_tests/aspect/lint_test.bats
@@ -101,3 +101,9 @@ EOF
     refute_output --partial "bazel-bin/shell.AspectRulesLintShellCheck.out.exit_code"
     refute_output --partial "bazel-bin/shell.AspectRulesLintShellCheck.patch"
 }
+
+@test 'aspect lint with no config should fail' {
+    echo '' >.aspect/cli/config.yaml
+    run aspect lint //:all
+    assert_failure
+}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
