### PR TITLE
fix: bare run target skipped as boolean flag value for otel span data

### DIFF
--- a/pkg/telemetry/bazel_attrs.go
+++ b/pkg/telemetry/bazel_attrs.go
@@ -68,9 +68,10 @@ func looksLikeBazelLabel(s string) bool {
 //
 // For space-separated flags ("--flag value" form), the value is skipped: a non-flag arg
 // that follows a "--flag" (no "=") and does not look like a Bazel label is treated as the
-// flag's value rather than a target.
+// flag's value rather than a target. If no targets are found (e.g. a boolean flag preceded
+// a bare target), the skipped args are returned as a fallback.
 func bazelTargets(cmd []string) []string {
-	var targets []string
+	var targets, skipped []string
 	args := cmd[1:]
 	for i, arg := range args {
 		if arg == "--" {
@@ -83,6 +84,7 @@ func bazelTargets(cmd []string) []string {
 		// started with "--" and had no "=", and this arg doesn't look like a label, treat
 		// it as the flag's value.
 		if i > 0 && strings.HasPrefix(args[i-1], "--") && !strings.Contains(args[i-1], "=") && !looksLikeBazelLabel(arg) {
+			skipped = append(skipped, arg)
 			continue
 		}
 		targets = append(targets, arg)
@@ -91,5 +93,11 @@ func bazelTargets(cmd []string) []string {
 			break
 		}
 	}
-	return targets
+	if len(targets) > 0 {
+		return targets
+	}
+	if cmd[0] == "run" && len(skipped) > 0 {
+		return skipped[len(skipped)-1:]
+	}
+	return nil
 }

--- a/pkg/telemetry/bazel_attrs_test.go
+++ b/pkg/telemetry/bazel_attrs_test.go
@@ -62,6 +62,26 @@ func TestBazelTargets(t *testing.T) {
 			want: []string{"//foo:bin"},
 		},
 		{
+			name: "run with boolean flag before bare target",
+			args: []string{"run", "--keep_going", "target"},
+			want: []string{"target"},
+		},
+		{
+			name: "run with multiple boolean flags before bare target",
+			args: []string{"run", "--keep_going", "--verbose_failures", "target"},
+			want: []string{"target"},
+		},
+		{
+			name: "run with space-separated flag value before bare target",
+			args: []string{"run", "--invocation_id", "abc-123", "target"},
+			want: []string{"target"},
+		},
+		{
+			name: "run with value flag then boolean flag before bare target",
+			args: []string{"run", "--invocation_id", "abc-123", "--keep_going", "target"},
+			want: []string{"target"},
+		},
+		{
 			name: "only -- separator",
 			args: []string{"run", "--", "//foo:bar"},
 			want: nil,
@@ -69,6 +89,11 @@ func TestBazelTargets(t *testing.T) {
 		{
 			name: "command only",
 			args: []string{"build"},
+			want: nil,
+		},
+		{
+			name: "build with only space-separated flag value",
+			args: []string{"build", "--flag", "value"},
 			want: nil,
 		},
 		{


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
