### PR TITLE
chore: remove old RBE footprint

### DIFF
--- a/integration_tests/bats.bzl
+++ b/integration_tests/bats.bzl
@@ -39,7 +39,6 @@ def bats_test(srcs = [], **kwargs):
         ] + helpers_dirs,
         env = env,
         args = tests + args,
-        # TODO(alex): remove when we green it up on RBE
-        tags = tags + ["no-remote-exec"],
+        tags = tags,
         **kwargs
     )

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -41,15 +41,3 @@ platform(
     ],
     parents = ["@platforms//host"],
 )
-
-platform(
-    name = "linux_x86_64_remote",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    exec_properties = {
-        "OSFamily": "Linux",
-        "container-image": "docker://public.ecr.aws/docker/library/python@sha256:247105bbbe7f7afc7c12ac893be65b5a32951c1d0276392dc2bf09861ba288a6",
-    },
-)


### PR DESCRIPTION
Removes leftover remote-build-execution (RBE) configuration that is no longer used, from `integration_tests/bats.bzl` and `platforms/BUILD.bazel`.